### PR TITLE
Update git:// github.com submodule URL to use https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "augeas"]
 	path = augeas
-	url = git://github.com/hercules-team/augeas.git
+	url = https://github.com/hercules-team/augeas.git


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

github.com permanently disabled unencrypted git on 15/3/22: https://github.blog/2021-09-01-improving-git-protocol-security-github/, which means that updating this repository's submodules currently fails.

This PR changes the submodule URL in question to an equivalent HTTPS URL that works.

#### This Pull Request (PR) fixes the following issues

n/a
