### PR TITLE
quote slash (/) as a key separator when communicating with augeas

### DIFF
--- a/lib/puppet/provider/sysctl/augeas.rb
+++ b/lib/puppet/provider/sysctl/augeas.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
   optional_commands :sysctl => 'sysctl'
 
   resource_path do |resource|
-    "$target/#{resource[:name]}"
+    "$target/#{resource[:name].gsub('/', '\/')}"
   end
 
   def self.sysctl_set(key, value, silent=false)
@@ -46,7 +46,7 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
       entries.each do |entry|
         next if resources.find{|x| x[:name] == entry}
 
-        value = aug.get("$target/#{entry}")
+        value = aug.get("$target/#{entry.gsub('/', '\/')}")
 
         if value
           resource = {
@@ -59,11 +59,11 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
 
           # Only match comments immediately before the entry and prefixed with
           # the sysctl name
-          cmtnode = aug.match("$target/#comment[following-sibling::*[1][self::#{entry}]]")
+          cmtnode = aug.match("$target/#comment[following-sibling::*[1][self::#{entry.gsub('/', '\/')}]]")
           unless cmtnode.empty?
             comment = aug.get(cmtnode[0])
-            if comment.match(/#{resource[:name]}:/)
-              resource[:comment] = comment.sub(/^#{resource[:name]}:\s*/, "")
+            if comment.match(/#{resource[:name].gsub('/', '\/')}:/)
+              resource[:comment] = comment.sub(/^#{resource[:name].gsub('/', '\/')}:\s*/, "")
             end
           end
 
@@ -268,7 +268,7 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
       if aug.match(cmtnode).empty?
         aug.insert('$resource', "#comment", true)
       end
-      aug.set("$target/#comment[following-sibling::*[1][self::#{resource[:name]}]]",
+      aug.set("$target/#comment[following-sibling::*[1][self::#{resource[:name].gsub('/', '\/')}]]",
               "#{resource[:name]}: #{resource[:comment]}")
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Quote sysctl keys with a slash in them

#### This Pull Request (PR) fixes the following issues
Partially fixes #17 by quoting slashes in keys (such as VLANs) when communicating with augeas 

This requires augeas 1.14.x with patch to [sysctl lens](https://github.com/hercules-team/augeas/pull/755), that supports more non-alphanumeric characters such as a slash. Have tested by directly copying ne wlens to `/opt/puppetlabs/puppet/share/augeas/lenses/dist/sysctl.aug` of puppet agent 7.25

A new puppet agent with augeas 1.14.x needs to be advocated

Note that the changes provided here are probably not optimal and possibly break with comments, but its at the limit of my current provider knowledge