### PR TITLE
[doc] Make it clear the default is to apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See [Puppet/Augeas pre-requisites](http://docs.puppetlabs.com/guides/augeas.html
 Type documentation can be generated with `puppet doc -r type` or viewed on the
 [Puppet Forge page](http://forge.puppetlabs.com/puppet/augeasproviders_sysctl).
 
+By default, `sysctl` settings are both applied to the running kernel configuration (via `sysctl -w`) and persisted to disk. See the `apply` and `persist` parameters to change this behavior.
 
 ### manage simple entry
 


### PR DESCRIPTION
#### Pull Request (PR) description

Update `README` to make it clear that the default is to apply sysctl rules.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-augeasproviders_sysctl/issues/12
